### PR TITLE
Addition required for Camera-agnostic movement

### DIFF
--- a/src/dagon/graphics/fpcamera2.d
+++ b/src/dagon/graphics/fpcamera2.d
@@ -74,6 +74,15 @@ class FirstPersonCamera2: EntityController
         return m;
     }
 
+    Matrix4x4f observerTrans()
+    {
+        Matrix4x4f m = translationMatrix(position);
+        // Rotate it by 90 degrees along the X-axis to make it "look up from the ground"
+        // and have the rest of the vectors (up, forward, right) actually point to where they should
+        m *= rotationMatrix(Axis.x, degtorad(-90f));
+        return m;
+    }
+
     override void update(Duration dt)
     {
         transformation = worldTrans();


### PR DESCRIPTION
This commit adds the "observerTrans()" method/member to FirstPersonCamera2

so that observers are no longer forced to move based on their LookAt vector's up/forward/right transforms, but rather the absolute observer actor's up/forward/right transforms.

This makes it able to "fly over" a battle while moving the camera to keep the fight in focus and have uninterrupted one-directional movement.

EDIT: bugfix, fixed the observerTrans() so that the forward/up/right vector point to where they should. well, once mouse is used to adjust to it's axes, the forward/backward, up/down, left/right movements move in intended directions instead of broken ones like before.

Includes necessary changes referenced in https://github.com/tg-2/sacengine/pull/10