### PR TITLE
Fix Camera-agnostic movement

### DIFF
--- a/src/dagon/graphics/fpcamera2.d
+++ b/src/dagon/graphics/fpcamera2.d
@@ -77,10 +77,12 @@ class FirstPersonCamera2: EntityController
     Matrix4x4f observerTrans()
     {
         Matrix4x4f m = translationMatrix(position);
-        m *= rotationMatrix(Axis.z, degtorad(turn));
         // Rotate it by 90 degrees along the X-axis to make it "look up from the ground"
         // and have the rest of the vectors (up, forward, right) actually point to where they should
         m *= rotationMatrix(Axis.x, degtorad(-90f));
+        // Also have it rotate to wherever you're looking at so that the controls remain consistent
+        // once you turn the camera by 180-degrees (so that "move left" still moves left instead of right)
+        m *= rotationMatrix(Axis.y, degtorad(turn));
         return m;
     }
 


### PR DESCRIPTION
After some deliberation and discussions, it became clear that mouse looking should actually rotate the spectator actor and not just move the camera around; since then the camera move forward/backward/left/right is actually context-dependent on where we're looking at, instead of just being in their own system and the spectator having to constantly readjust (and re-learn) where each movement goes.

So, now it has been changed to be more helicopter-like. This change also makes the Camera Left/Right movement completely analogous to default Move Left/Right so they should be removed, since this change makes them duplicated code.

The difference between default Move Left/Right and Camera Left/Right is only in a situation that never happens - had we the ability to rotate (roll) the player character like an airplane can, the difference between Move Left if it was banked at 90-degress to the left side would have became obvious - Move Left would move down whereas Camera Left would still move left.

But since that sort of movement isn't supported, we should just get rid of them.